### PR TITLE
Enhance game items and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Getting Started with Create React App
+# Medieval Shop Simulator
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+An isometric shop management game built with React and TypeScript.
 
 ## Available Scripts
 
@@ -38,6 +38,21 @@ If you aren’t satisfied with the build tool and configuration choices, you can
 Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
 You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+## Contributing
+
+1. Clone the repository and run `npm install`.
+2. Use `npm start` to run the development server.
+3. Add tests with `npm test` and ensure they pass before submitting a pull request.
+
+## Project Structure
+
+Game logic lives in `src/components`. Each React hook encapsulates a piece of functionality such as state handling or customer behaviors.
+
+## Building for Production
+
+Run `npm run build:prod` to create an optimized build in the `build/` directory.
+
 
 ## Learn More
 

--- a/src/components/gameConstants.tsx
+++ b/src/components/gameConstants.tsx
@@ -11,14 +11,20 @@ export const ITEM_TYPES = {
   sword: { name: 'Iron Sword', color: '#C0C0C0', shape: 'rect', size: 20, basePrice: 50, category: 'weapon' },
   potion: { name: 'Health Potion', color: '#FF1493', shape: 'triangle', size: 12, basePrice: 25, category: 'consumable' },
   hammer: { name: 'Hammer', color: '#8B4513', shape: 'rect', size: 18, basePrice: 30, category: 'tool' },
-  apple: { name: 'Apple', color: '#FF0000', shape: 'circle', size: 10, basePrice: 3, category: 'food' }
+  apple: { name: 'Apple', color: '#FF0000', shape: 'circle', size: 10, basePrice: 3, category: 'food' },
+  helmet: { name: 'Helmet', color: '#808080', shape: 'rect', size: 18, basePrice: 40, category: 'armor' },
+  armor: { name: 'Chain Armor', color: '#A9A9A9', shape: 'rect', size: 22, basePrice: 80, category: 'armor' },
+  ring: { name: 'Magic Ring', color: '#FFD700', shape: 'circle', size: 8, basePrice: 100, category: 'artifact' },
+  scroll: { name: 'Spell Scroll', color: '#FFFFE0', shape: 'rect', size: 10, basePrice: 60, category: 'artifact' }
 } as const;
 
 // Furniture types
 export const FURNITURE_TYPES = {
   shelf: { name: 'Wooden Shelf', color: '#8B4513', slots: 3, height: 30 },
   counter: { name: 'Counter', color: '#654321', slots: 4, height: 20 },
-  display: { name: 'Display Case', color: '#4682B4', slots: 2, height: 25 }
+  display: { name: 'Display Case', color: '#4682B4', slots: 2, height: 25 },
+  weaponRack: { name: 'Weapon Rack', color: '#5D4037', slots: 4, height: 40 },
+  potionStand: { name: 'Potion Stand', color: '#9C27B0', slots: 3, height: 35 }
 } as const;
 
 // Customer archetypes

--- a/src/components/isometricUtils.test.ts
+++ b/src/components/isometricUtils.test.ts
@@ -1,0 +1,14 @@
+import { calculateDynamicPrice } from './isometricUtils';
+import { Market } from './gameConstants';
+
+describe('calculateDynamicPrice', () => {
+  it('applies demand and supply multipliers', () => {
+    const market = {
+      demand: { bread: 1.5 } as any,
+      supply: { bread: 'low' } as any,
+      priceHistory: {}
+    } as unknown as Market;
+    const price = calculateDynamicPrice('bread' as any, 10, market);
+    expect(price).toBeGreaterThan(10);
+  });
+});

--- a/src/components/isometricUtils.tsx
+++ b/src/components/isometricUtils.tsx
@@ -191,9 +191,17 @@ export const drawFurniture = (
   } else if (furniture.type === 'display') {
     ctx.fillStyle = furnitureType.color;
     ctx.fillRect(screenX - 20, screenY - furnitureType.height, 40, furnitureType.height + 10);
-    
+
     ctx.fillStyle = 'rgba(135, 206, 235, 0.3)';
     ctx.fillRect(screenX - 18, screenY - furnitureType.height + 2, 36, furnitureType.height - 4);
+  } else if (furniture.type === 'weaponRack') {
+    ctx.fillRect(screenX - 25, screenY - furnitureType.height, 50, furnitureType.height + 5);
+    ctx.fillStyle = '#3E2723';
+    ctx.fillRect(screenX - 25, screenY - furnitureType.height, 50, 3);
+  } else if (furniture.type === 'potionStand') {
+    ctx.fillRect(screenX - 15, screenY - furnitureType.height, 30, furnitureType.height);
+    ctx.fillStyle = '#4A148C';
+    ctx.fillRect(screenX - 15, screenY - furnitureType.height, 30, 3);
   }
   
   // Draw slot indicators in placement mode

--- a/src/components/useGameState.tsx
+++ b/src/components/useGameState.tsx
@@ -6,8 +6,18 @@ import {
   type Notification
 } from './gameConstants';
 
-// Initial game state factory
+// Initial game state factory. Attempts to load from localStorage if available
 const createInitialGameState = (): GameState => {
+  if (typeof window !== 'undefined') {
+    const saved = localStorage.getItem('medievalGameState');
+    if (saved) {
+      try {
+        return JSON.parse(saved) as GameState;
+      } catch {
+        // fall through to create default state
+      }
+    }
+  }
   // Initialize shop tiles
   const tiles: { type: 'floor' | 'wall' | 'door'; color: string }[][] = [];
   for (let y = 0; y < 8; y++) {
@@ -39,7 +49,9 @@ const createInitialGameState = (): GameState => {
     { id: 2, type: 'shelf' as const, x: 1, y: 3, items: [] },
     { id: 3, type: 'counter' as const, x: 4, y: 5, items: [] },
     { id: 4, type: 'display' as const, x: 7, y: 1, items: [] },
-    { id: 5, type: 'display' as const, x: 7, y: 3, items: [] }
+    { id: 5, type: 'display' as const, x: 7, y: 3, items: [] },
+    { id: 6, type: 'weaponRack' as const, x: 2, y: 5, items: [] },
+    { id: 7, type: 'potionStand' as const, x: 5, y: 2, items: [] }
   ];
 
   return {
@@ -56,7 +68,11 @@ const createInitialGameState = (): GameState => {
       { id: 2, type: 'sword', quantity: 5, averageCost: 35 },
       { id: 3, type: 'potion', quantity: 8, averageCost: 18 },
       { id: 4, type: 'hammer', quantity: 6, averageCost: 22 },
-      { id: 5, type: 'apple', quantity: 15, averageCost: 2 }
+      { id: 5, type: 'apple', quantity: 15, averageCost: 2 },
+      { id: 6, type: 'helmet', quantity: 2, averageCost: 30 },
+      { id: 7, type: 'armor', quantity: 1, averageCost: 60 },
+      { id: 8, type: 'ring', quantity: 1, averageCost: 80 },
+      { id: 9, type: 'scroll', quantity: 3, averageCost: 40 }
     ],
     gold: 500,
     market: {
@@ -65,14 +81,22 @@ const createInitialGameState = (): GameState => {
         sword: 1.0,
         potion: 1.0,
         hammer: 1.0,
-        apple: 1.0
+        apple: 1.0,
+        helmet: 1.0,
+        armor: 1.0,
+        ring: 1.0,
+        scroll: 1.0
       },
       supply: {
         bread: 'high',
         sword: 'medium',
         potion: 'medium',
         hammer: 'medium',
-        apple: 'high'
+        apple: 'high',
+        helmet: 'low',
+        armor: 'low',
+        ring: 'low',
+        scroll: 'medium'
       },
       priceHistory: {}
     },
@@ -83,7 +107,11 @@ const createInitialGameState = (): GameState => {
         { type: 'sword', quantity: 10, price: 35 },
         { type: 'potion', quantity: 15, price: 18 },
         { type: 'hammer', quantity: 12, price: 22 },
-        { type: 'apple', quantity: 30, price: 2 }
+        { type: 'apple', quantity: 30, price: 2 },
+        { type: 'helmet', quantity: 5, price: 32 },
+        { type: 'armor', quantity: 3, price: 70 },
+        { type: 'ring', quantity: 2, price: 90 },
+        { type: 'scroll', quantity: 10, price: 45 }
       ]
     },
     customers: [],
@@ -108,6 +136,13 @@ const createInitialGameState = (): GameState => {
 
 export const useGameState = () => {
   const [gameState, setGameState] = useState<GameState>(createInitialGameState);
+
+  // Persist game state to localStorage whenever it changes
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('medievalGameState', JSON.stringify(gameState));
+    }
+  }, [gameState]);
 
   // Show notification helper
   const showNotification = useCallback((message: string, type: 'info' | 'success' | 'error' = 'info') => {


### PR DESCRIPTION
## Summary
- expand `ITEM_TYPES` with armor and magical artifacts
- add new furniture for weapons and potions
- persist game state in localStorage
- basic unit test for `calculateDynamicPrice`
- update docs with contributing notes

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6846fa0c43d4832a9426069117553869